### PR TITLE
Add projects team as blog authors

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -19,7 +19,7 @@ caniszczyk:
 idvoretskyi:
   name: Ihor Dvoretskyi
   page: true
-  title: fixme
+  title: Senior Developer Advocate
   url: https://github.com/idvoretskyi
   image_url: https://github.com/idvoretskyi.png
   email: ihor@cncf.io


### PR DESCRIPTION
Added authors to contrib site, not sure what emails/social you want to use so left some fixmes: @idvoretskyi @jeefy @mrbobbytables @krook @nate-double-u 

Added cra in case he ever needs to post here. 

Example author page: https://docusaurus.io/blog/authors