### PR TITLE
Add GTM container

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -72,6 +72,9 @@ const config = {
         theme: {
           customCss: './src/css/custom.css',
         },
+        googleTagManager: {
+          containerId: 'GTM-WJJ7VKZ',
+        },
       }),
     ],
   ],


### PR DESCRIPTION
Adds the standard CNCF subsite GTM container that includes GA4 and HubSpot.