### PR TITLE
fix: resolve /search route conflict and restore typecheck

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -93,7 +93,7 @@ const config = {
       ],
       announcementBar: {
         id: `hello-bar`,
-        content: `🎉️ The CFP for the CNCF Maintainer Summit Europe 2026 closes December 14 · <b><a target="_blank" href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/features-add-ons/maintainer-summit/#call-for-proposals">Submit Today!</b>`,
+        content: `🎉️ The CFP for the CNCF Maintainer Summit Europe 2026 closes December 14 · <b><a target="_blank" rel="noopener noreferrer" href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/features-add-ons/maintainer-summit/#call-for-proposals">Submit Today!</a></b>`,
         backgroundColor: 'rgb(1, 117, 228)', // Defaults to `#fff`
         textColor: '#fff', // Defaults to `#000`
       },

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -7,7 +7,7 @@ const FeatureList = [
   {
     title: 'Contributors',
     Svg: require('@site/static/img/CNCF-Contributor-Icons-Contributor.svg').default,
-    link: '/maintainers',
+    link: '/contributors',
     description: (
       <>
         Navigate the Cloud Native as an individual contributor. Get started, find new friends, forge your path.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@docusaurus/tsconfig",
+  "include": ["docusaurus.config.js", "sidebars.js"]
+}


### PR DESCRIPTION
### What changed
- Removed `docs/search.md`, which was creating a second `/search` route (Docusaurus already provides `/search` via the local search plugin).
- Added `tsconfig.json` so the existing `npm run typecheck` script no longer fails.
- Corrected the homepage "Contributors" card link to point to `/contributors` (previously linked to `/maintainers`).
- Corrected malformed HTML in the announcement bar so the link markup is valid.

### Why
- The build produced a **Duplicate routes found** warning for `/search`, which can lead to non-deterministic routing.
- `npm run typecheck` previously failed because `tsc` had no project configuration.
- Homepage navigation contained a mismatched destination for the "Contributors" call-to-action.
- The announcement bar HTML had an unclosed anchor tag.

### Impact
- Removes a route conflict warning and avoids ambiguous routing.
- Restores a working typecheck command for contributors.
- Improves navigation correctness on the homepage.
- No functional feature additions; changes are strictly corrective.