### PR TITLE
docs: clarify navigation for Best Practices container pages (#154)

### DIFF
--- a/docs/projects/best-practices/index.md
+++ b/docs/projects/best-practices/index.md
@@ -3,3 +3,10 @@ title: Project Best Practices
 sidebar_label: Best Practices
 sidebar_position: 3
 ---
+
+import DocCardList from '@theme/DocCardList';
+
+This section contains CNCF Best Practices documentation organized by topic.
+Some pages act as containers for related guidance—use the navigation on the left to explore the available content.
+
+<DocCardList />


### PR DESCRIPTION
This PR adds a short explanatory note to the Best Practices landing page to clarify
that content is organized by topic and accessible via the left-hand navigation.

The goal is to reduce confusion for first-time visitors while keeping the existing
content structure unchanged.
