### PR TITLE
Fix horizontal overflow on small mobile viewports

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -107,4 +107,34 @@
 
 .navbar__logo:not(#\#):not(#\#) {
   height: 2.5rem;
+  max-width: 100%;
+  transition: max-width 0.3s ease;
+}
+
+.navbar__logo img {
+  transition: max-height 0.3s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .navbar__logo,
+  .navbar__logo img {
+    transition: none;
+  }
+}
+
+@media (max-width: 330px) {
+
+  .navbar__logo:not(#\#):not(#\#) {
+    max-width: 80%;
+  }
+
+  .button_zS_t:not(#\#) {
+	margin-left: 0;
+  }
+
+}
+
+.socialIcons_t1qu:not(#\#):not(#\#) {
+  flex-wrap: wrap;
+  justify-content: center;
 }


### PR DESCRIPTION
### Problem
On small mobile viewports (e.g. iPhone SE, Samsung Galaxy Z Fold 5), the layout introduces horizontal overflow, resulting in an unwanted x-axis scrollbar.

### Root Cause
Certain elements exceeded the viewport width at small screen sizes, causing horizontal overflow.

### Solution
Adjusted CSS to prevent horizontal overflow on narrow screens without affecting desktop or tablet layouts.

### Screenshots

**Before:**

<img width="1920" height="1029" alt="image" src="https://github.com/user-attachments/assets/66dfe373-b968-40fd-8945-a7b99648138a" />

<img width="1920" height="1031" alt="image" src="https://github.com/user-attachments/assets/efebe283-4efc-44b6-88f1-d61cba57c0fb" />


**After:**

<img width="1920" height="1031" alt="image" src="https://github.com/user-attachments/assets/5a0d824c-9cbd-4fb5-b996-20f5b1699762" />

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/f8b63844-e105-4a45-8ffb-e23350ac62cb" />


<details>
<summary> Galaxy Z Fold 5 (verification)</summary>

**Before:**

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/2034d421-703d-4d93-96bc-06dada7f2ccb" />

<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/ccb88055-82dd-4078-9a3e-6c3e81ab8fc4" />


**After:**

<img width="1920" height="1031" alt="image" src="https://github.com/user-attachments/assets/fa56c3aa-4ba5-4420-81ba-848bed3f2d46" />

<img width="1920" height="1029" alt="image" src="https://github.com/user-attachments/assets/9053fec0-1ac3-4941-bf27-ab1b45b3f2dd" />


</details>

### Notes
- CSS-only change
- No JavaScript changes
- Tested on mobile-sized viewports
