### PR TITLE
Improve navbar responsiveness to prevent overlap at intermediate widths

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -108,3 +108,79 @@
 .navbar__logo:not(#\#):not(#\#) {
   height: 2.5rem;
 }
+
+.navbar__item, .navbarSearchContainer_Bca1, .DocSearch-Button-Placeholder {
+  transition: font-size 0.3s ease, padding-inline 0.3s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .navbarSearchContainer_Bca1,
+  .DocSearch-Button-Placeholder {
+    transition: none;
+  }
+}
+
+@media (max-width: 1290px) and (min-width: 997px) {
+
+  .navbar__item:not(#\#):not(#\#) {
+    padding-inline: 0.5rem;
+    font-size: 0.9rem;
+  }
+
+  .navbar__logo:not(#\#):not(#\#) {
+	display: flex;
+	align-items: center;
+  }
+
+}
+
+@media (max-width: 1230px) and (min-width: 997px) {
+
+  .navbar__item:not(#\#):not(#\#) {
+    padding-inline: 0.3rem;
+  }
+
+}
+
+@media (max-width: 1120px) and (min-width: 997px) {
+
+  .navbar__logo:not(#\#):not(#\#) img {
+	max-height: 90%;
+  }
+
+  .DocSearch-Button:not(#\#) {
+	padding: 0 6px;
+	margin: 0 0 0 2px;
+  }
+
+  .navbarSearchContainer_Bca1:not(#\#_Z9eR):not(#\#_Z9eR):not(#\#_Z9eR) {
+	padding-left: 4px;
+  }
+
+}
+
+@media (max-width: 1080px) and (min-width: 997px) {
+
+  .navbar__logo:not(#\#):not(#\#) img {
+	max-height: 80%;
+  }
+
+  .DocSearch-Button-Placeholder:not(#\#) {
+    font-size: 0.9rem;
+    padding: 0 8px 0 4px;
+  }
+
+}
+
+@media (max-width: 1040px) and (min-width: 997px) {
+
+  .navbar__logo:not(#\#):not(#\#) img {
+	max-height: 72%;
+  }
+
+  .navbar__item:not(#\#):not(#\#) {
+    padding-inline: 0.3rem;
+    font-size: 0.85rem;
+  }
+
+}


### PR DESCRIPTION
### Problem
At intermediate viewport widths (roughly between the desktop and mobile breakpoints, ~996px–1290px), the horizontal navbar layout causes text and elements to overlap, reducing readability and usability.


### Root Cause
Navbar items and related elements did not scale or adjust consistently at these widths, leading to insufficient space allocation before the mobile layout breakpoint is reached.

### Solution
Adjusted CSS rules at the affected breakpoints to improve spacing and sizing behavior, ensuring navbar items adapt correctly and no longer overlap.

### Screenshots

<details>

<summary>Before / After (~1045px viewport)</summary>

**Before:**

<img width="1920" height="1031" alt="image" src="https://github.com/user-attachments/assets/ce477d7f-de75-434d-aa4a-c1fd47b29da8" />

**After:**

<img width="1920" height="1028" alt="image" src="https://github.com/user-attachments/assets/790b2447-bb45-4827-8250-24a697c8d95f" />


</details>

### Notes
- CSS-only change
- Does not affect mobile or desktop layouts
- Tested across intermediate viewport widths
