### PR TITLE
Tweak footer and social icon spacing to fix overflow on mobile

### DIFF
--- a/src/theme/Footer/styles.module.css
+++ b/src/theme/Footer/styles.module.css
@@ -10,6 +10,8 @@
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
+  row-gap: 10px;
+  column-gap: 30px;
 }
 
 .left {
@@ -55,11 +57,11 @@
 
 .socialIcons {
   display: flex;
-  gap: 1rem;
+  gap: 1.5rem;
 }
 
 .socialIcons a {
-    padding: 17px;
+  padding: 1rem 0 1rem 0;
 }
 
 .socialIcons svg {


### PR DESCRIPTION
- Fixes #197
- The only element that I found overflowing on mobile is the social icon list. The main problem is that is has too much padding.
- Removes the horizontal padding between icons
- Instead adds a bit more gap between them
- Adds a gap between footer top-row elements so that they don't colide when the display is being made narrower (esp. between the icons and the All Sites button.
- Adds a row gap between the buttons and icon 
- Closes #193 by superseding it

### Screenshots

| Before | After |
|--------|--------|
| <img width="377" height="668" alt="image" src="https://github.com/user-attachments/assets/f5febce2-29c1-421b-a20f-a9ec1bdd46af" /> | <img width="374" height="667" alt="image" src="https://github.com/user-attachments/assets/8f440440-e725-4297-8599-552e739c323e" /> | 

The design can be improved further, but I'll open a followup issue for that. See:

- #199

/cc @nate-double-u 