### PR TITLE
fix: allow link checker to update issues on scheduled runs

### DIFF
--- a/.github/workflows/link-checker.lock.yml
+++ b/.github/workflows/link-checker.lock.yml
@@ -25,7 +25,7 @@
 # (including synced techdocs content), distinguishes real broken links from
 # transient failures, and creates/updates GitHub issues with actionable results.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a47409de4b67212bc6bdd72ad817fc27ec32b0e73af86ae67fd53f2527555ed0","compiler_version":"v0.57.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a75f228ca17e767c86ea12c66a2b2176a5930a22a4efbc1429faca88d6a0f3b6","compiler_version":"v0.57.2","strict":true}
 
 name: "Link Checker"
 "on":
@@ -437,7 +437,7 @@ jobs:
               "name": "add_labels"
             },
             {
-              "description": "Update an existing GitHub issue's title, body, labels, assignees, or milestone WITHOUT closing it. This tool is primarily for editing issue metadata and content. While it supports changing status between 'open' and 'closed', use close_issue instead when you want to close an issue with a closing comment. Body updates support replacing, appending to, prepending content, or updating a per-run \"island\" section. CONSTRAINTS: Maximum 10 issue(s) can be updated.",
+              "description": "Update an existing GitHub issue's title, body, labels, assignees, or milestone WITHOUT closing it. This tool is primarily for editing issue metadata and content. While it supports changing status between 'open' and 'closed', use close_issue instead when you want to close an issue with a closing comment. Body updates support replacing, appending to, prepending content, or updating a per-run \"island\" section. CONSTRAINTS: Maximum 10 issue(s) can be updated. Target: *.",
               "inputSchema": {
                 "additionalProperties": false,
                 "properties": {
@@ -1348,7 +1348,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.cncf.io,*.githubusercontent.com,*.kubernetes.io,*.linuxfoundation.org,*.openssf.org,*.owasp.org,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,bestpractices.coreinfrastructure.org,clomonitor.io,clotributor.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,csrc.nist.gov,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,kubernetes.io,lfs.github.com,nvlpubs.nist.gov,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,openssf.org,owasp.org,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,securityscorecards.dev,telemetry.enterprise.githubcopilot.com,todogroup.org,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"allowed\":[\"broken-link\",\"techdocs-upstream\"]},\"create_issue\":{\"max\":10},\"missing_data\":{},\"missing_tool\":{},\"update_issue\":{\"allow_body\":true,\"max\":10}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"allowed\":[\"broken-link\",\"techdocs-upstream\"]},\"create_issue\":{\"max\":10},\"missing_data\":{},\"missing_tool\":{},\"update_issue\":{\"allow_body\":true,\"max\":10,\"target\":\"*\"}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/link-checker.md
+++ b/.github/workflows/link-checker.md
@@ -39,6 +39,7 @@ safe-outputs:
     max: 10
   update-issue:
     max: 10
+    target: "*"
 
 tools:
   github:


### PR DESCRIPTION
## Problem

The link checker workflow ([run #23080168198](https://github.com/cncf/contribute-site/actions/runs/23080168198)) fails on every scheduled run because the `update-issue` safe-output defaults to `target: "triggering"`. Since scheduled runs have no triggering issue, all `update_issue` calls are rejected:

```
Target is "triggering" but not running in issue context, skipping update_issue
```

All 8 broken-link issue updates failed with this error.

## Fix

Set `target: "*"` on the `update-issue` safe-output config, which allows the agent to update issues by explicitly providing an `issue_number`. This is the correct mode for `schedule` and `workflow_dispatch` triggers where there is no triggering issue.

## Changes

- **`link-checker.md`**: Added `target: "*"` to `update-issue` config
- **`link-checker.lock.yml`**: Recompiled via `gh aw compile`