### PR TITLE
feat: create techdocs broken-link issues in cncf/techdocs

### DIFF
--- a/.github/workflows/link-checker.lock.yml
+++ b/.github/workflows/link-checker.lock.yml
@@ -25,7 +25,7 @@
 # (including synced techdocs content), distinguishes real broken links from
 # transient failures, and creates/updates GitHub issues with actionable results.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"a75f228ca17e767c86ea12c66a2b2176a5930a22a4efbc1429faca88d6a0f3b6","compiler_version":"v0.57.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"2ca77d7554b9e6f9cca7e23e9c475398ebb6b03651cf25faa066fdf4770c1b9d","compiler_version":"v0.57.2","strict":true}
 
 name: "Link Checker"
 "on":
@@ -287,9 +287,9 @@ jobs:
           (github.event.pull_request) || (github.event.issue.pull_request)
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.COPILOT_CROSS_REPO_TOKEN }}
         with:
-          github-token: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COPILOT_CROSS_REPO_TOKEN }}
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
@@ -347,6 +347,10 @@ jobs:
                       "number",
                       "string"
                     ]
+                  },
+                  "repo": {
+                    "description": "Target repository for this operation in 'owner/repo' format. Must be the target-repo or in the allowed-repos list.",
+                    "type": "string"
                   },
                   "secrecy": {
                     "description": "Confidentiality level of the message content (e.g., \"public\", \"internal\", \"private\").",
@@ -485,6 +489,10 @@ jobs:
                       "prepend",
                       "replace-island"
                     ],
+                    "type": "string"
+                  },
+                  "repo": {
+                    "description": "Target repository for this operation in 'owner/repo' format. Must be the target-repo or in the allowed-repos list.",
                     "type": "string"
                   },
                   "secrecy": {
@@ -974,7 +982,8 @@ jobs:
             const { main } = require('/opt/gh-aw/actions/redact_secrets.cjs');
             await main();
         env:
-          GH_AW_SECRET_NAMES: 'COPILOT_GITHUB_TOKEN,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
+          GH_AW_SECRET_NAMES: 'COPILOT_CROSS_REPO_TOKEN,COPILOT_GITHUB_TOKEN,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN'
+          SECRET_COPILOT_CROSS_REPO_TOKEN: ${{ secrets.COPILOT_CROSS_REPO_TOKEN }}
           SECRET_COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           SECRET_GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
           SECRET_GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
@@ -1237,7 +1246,7 @@ jobs:
           GH_AW_NOOP_MAX: "1"
           GH_AW_WORKFLOW_NAME: "Link Checker"
         with:
-          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COPILOT_CROSS_REPO_TOKEN }}
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
@@ -1250,7 +1259,7 @@ jobs:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
           GH_AW_WORKFLOW_NAME: "Link Checker"
         with:
-          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COPILOT_CROSS_REPO_TOKEN }}
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
@@ -1272,7 +1281,7 @@ jobs:
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
           GH_AW_TIMEOUT_MINUTES: "60"
         with:
-          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COPILOT_CROSS_REPO_TOKEN }}
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
@@ -1289,7 +1298,7 @@ jobs:
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
           GH_AW_NOOP_REPORT_AS_ISSUE: "true"
         with:
-          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COPILOT_CROSS_REPO_TOKEN }}
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
@@ -1348,9 +1357,9 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.cncf.io,*.githubusercontent.com,*.kubernetes.io,*.linuxfoundation.org,*.openssf.org,*.owasp.org,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,bestpractices.coreinfrastructure.org,clomonitor.io,clotributor.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,csrc.nist.gov,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,kubernetes.io,lfs.github.com,nvlpubs.nist.gov,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,openssf.org,owasp.org,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,securityscorecards.dev,telemetry.enterprise.githubcopilot.com,todogroup.org,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"allowed\":[\"broken-link\",\"techdocs-upstream\"]},\"create_issue\":{\"max\":10},\"missing_data\":{},\"missing_tool\":{},\"update_issue\":{\"allow_body\":true,\"max\":10,\"target\":\"*\"}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"allowed\":[\"broken-link\",\"techdocs-upstream\"]},\"create_issue\":{\"allowed_repos\":[\"cncf/techdocs\"],\"max\":10},\"missing_data\":{},\"missing_tool\":{},\"update_issue\":{\"allow_body\":true,\"allowed_repos\":[\"cncf/techdocs\"],\"max\":10,\"target\":\"*\"}}"
         with:
-          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COPILOT_CROSS_REPO_TOKEN }}
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);

--- a/.github/workflows/link-checker.md
+++ b/.github/workflows/link-checker.md
@@ -32,14 +32,17 @@ network:
     - "*.openssf.org"
 
 safe-outputs:
+  github-token: ${{ secrets.COPILOT_CROSS_REPO_TOKEN }}
   add-comment:
   add-labels:
     allowed: [broken-link, techdocs-upstream]
   create-issue:
     max: 10
+    allowed-repos: ["cncf/techdocs"]
   update-issue:
     max: 10
     target: "*"
+    allowed-repos: ["cncf/techdocs"]
 
 tools:
   github:
@@ -131,7 +134,9 @@ Group broken links by **top-level content section** based on file path. The sect
 
 For each section that has broken or possibly transient links, search for an existing open issue with the label `broken-link` and a title matching that section. Use the GitHub MCP tools for all issue operations (the `gh` CLI is not authenticated in this environment):
 
-1. Use `list_issues` with `owner: "cncf"`, `repo: "contribute-site"`, label filter `broken-link`, and state `open` to find existing section issues
+1. Use `list_issues` with label filter `broken-link` and state `open` to find existing section issues
+   - For `docs/techdocs/` sections: search in `owner: "cncf"`, `repo: "techdocs"`
+   - For all other sections: search in `owner: "cncf"`, `repo: "contribute-site"`
 2. Match by title prefix: `Broken links: <Section Name>`
 
 **For each section with problems:**
@@ -141,9 +146,9 @@ For each section that has broken or possibly transient links, search for an exis
 - Title format: `Broken links: <Section Name>`
   - Example: `Broken links: Community`, `Broken links: Blog`, `Broken links: TechDocs`
 
-**For `docs/techdocs/` issues**, also add the label `techdocs-upstream` and include a note at the top of the issue body:
+**For `docs/techdocs/` issues**, create or update the issue in `cncf/techdocs` (not in this repository) by passing `repo: "cncf/techdocs"` to the `create_issue` or `update_issue` tool. Include a note at the top of the issue body:
 
-> ⚠️ These files are synced from [cncf/techdocs](https://github.com/cncf/techdocs). Fixes should be made in that repository, not here.
+> 🔗 Detected by the [contribute-site link checker](https://github.com/cncf/contribute-site/actions). These links were checked against the content as it appears on [contribute.cncf.io](https://contribute.cncf.io).
 
 Use this format for each issue body:
 
@@ -167,7 +172,7 @@ Last run: [Workflow Run](https://github.com/${{ github.repository }}/actions/run
 - Z links checked successfully
 ```
 
-**For sections where all links are now OK:** if an issue for that section is open, close it using `update_issue` (set `state: "closed"`) with a comment saying all links in that section are now valid.
+**For sections where all links are now OK:** if an issue for that section is open, close it using `update_issue` (set `state: "closed"`). Use the same repo where the issue was created — `cncf/techdocs` for TechDocs sections, `cncf/contribute-site` for everything else.
 
 If all links across the entire site are OK and no issues exist, exit silently.
 
@@ -212,7 +217,7 @@ These domains are known to have intermittent availability, rate-limit automated 
 5. Do not fail the workflow — use issues for feedback
 6. Be concise — developers should be able to fix issues quickly from the report
 7. Close section issues when all links in that section are valid
-8. For files under `docs/techdocs/`, also label with `techdocs-upstream`
+8. For `docs/techdocs/` sections, create issues in `cncf/techdocs` by passing `repo: "cncf/techdocs"` to the safe-output tools
 9. Skip external URLs that return `000` (firewall-blocked domains) — do not report them
 
 ### Exit Conditions


### PR DESCRIPTION
## Summary

Broken links found in `docs/techdocs/` (synced from `cncf/techdocs`) were previously filed as issues in `cncf/contribute-site`, but fixes need to happen upstream. This PR configures the link checker to create those issues directly in `cncf/techdocs`.

## Changes

- **`safe-outputs` config**: Added `github-token` for cross-repo auth and `allowed-repos: ["cncf/techdocs"]` on `create-issue` and `update-issue`
- **Prompt**: Updated issue search, creation, and closing logic to route `docs/techdocs/` issues to `cncf/techdocs` and all other sections to `cncf/contribute-site`

## Setup (completed)

- [x] `COPILOT_CROSS_REPO_TOKEN` secret created in `cncf/contribute-site` (fine-grained PAT with `issues:write` on both repos)
- [x] `broken-link` label exists in `cncf/techdocs`

## References

- [Cross-Repository Operations docs](https://github.github.com/gh-aw/reference/cross-repository/)
- [Safe Outputs docs](https://github.github.com/gh-aw/reference/safe-outputs/)
- Related: #237 (techdocs broken links currently filed in contribute-site)