### PR TITLE
feat: auto-assign Copilot to broken-link issues with fix guidelines

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,6 +63,16 @@ Be very strict with the instructions in this section:
 - Always ensure that the vocabulary and definitions for everything you create match the official definitions in @cncf/glossary
 - Use https://github.com/cncf/toc/blob/main/tags.yaml as the source of truth for individuals who participate in CNCF activities. When modifying any page that lists people, positions, or affiliations, verify against this file and update the page accordingly; if the upstream data is outdated, also submit a PR to @cncf/toc to correct it. 
 
+## Broken Link Fixes
+
+When assigned an issue with the `broken-link` label, follow these rules:
+
+- **One PR per page.** Group all broken link fixes for a single file into one pull request. Do not combine fixes across multiple files into a single PR.
+- **Do not touch URLs inside backticks.** If a URL appears inside inline code (`` ` ``) or a fenced code block, leave it alone — it is a code reference, not a navigable link.
+- **Fix only the link, not the surrounding content.** Do not rewrite sentences, reformat paragraphs, or make unrelated edits. The diff should contain only the corrected URLs.
+- **Verify replacements.** Before submitting, confirm that the new URL returns a 200 status and points to the correct content.
+- **If no valid replacement exists,** do not guess. Instead, leave a comment on the issue explaining which link could not be resolved and why, so a maintainer can decide what to do.
+- **Reference the issue.** Include `Contributes to #<issue-number>` in the PR description. Do not use `Fixes` or `Closes` — a single-page PR will not resolve the entire issue.
 
 ## Style Guide
 

--- a/.github/workflows/link-checker.lock.yml
+++ b/.github/workflows/link-checker.lock.yml
@@ -25,7 +25,7 @@
 # (including synced techdocs content), distinguishes real broken links from
 # transient failures, and creates/updates GitHub issues with actionable results.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"b349b99250e72eb0b01ec681c411cf5f881a901417c7e2efd84ce3f7b1a36eed","compiler_version":"v0.57.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"2aa69c8a4eaf75891ccec91368e1ce53577e7e82c49bf6dc9289dc2ec91e79db","compiler_version":"v0.57.2","strict":true}
 
 name: "Link Checker"
 "on":
@@ -322,7 +322,7 @@ jobs:
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
             {
-              "description": "Create a new GitHub issue for tracking bugs, feature requests, or tasks. Use this for actionable work items that need assignment, labeling, and status tracking. For reports, announcements, or status updates that don't require task tracking, use create_discussion instead. CONSTRAINTS: Maximum 10 issue(s) can be created.",
+              "description": "Create a new GitHub issue for tracking bugs, feature requests, or tasks. Use this for actionable work items that need assignment, labeling, and status tracking. For reports, announcements, or status updates that don't require task tracking, use create_discussion instead. CONSTRAINTS: Maximum 10 issue(s) can be created. Assignees [\"copilot\"] will be automatically assigned.",
               "inputSchema": {
                 "additionalProperties": false,
                 "properties": {
@@ -1357,13 +1357,26 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.cncf.io,*.githubusercontent.com,*.kubernetes.io,*.linuxfoundation.org,*.openssf.org,*.owasp.org,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,bestpractices.coreinfrastructure.org,clomonitor.io,clotributor.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,csrc.nist.gov,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,kubernetes.io,lfs.github.com,nvlpubs.nist.gov,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,openssf.org,owasp.org,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,securityscorecards.dev,telemetry.enterprise.githubcopilot.com,todogroup.org,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"allowed\":[\"broken-link\"]},\"create_issue\":{\"allowed_repos\":[\"cncf/techdocs\"],\"max\":10},\"missing_data\":{},\"missing_tool\":{},\"update_issue\":{\"allow_body\":true,\"allowed_repos\":[\"cncf/techdocs\"],\"max\":10,\"target\":\"*\"}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"allowed\":[\"broken-link\"]},\"create_issue\":{\"allowed_repos\":[\"cncf/techdocs\"],\"assignees\":[\"copilot\"],\"max\":10},\"missing_data\":{},\"missing_tool\":{},\"update_issue\":{\"allow_body\":true,\"allowed_repos\":[\"cncf/techdocs\"],\"max\":10,\"target\":\"*\"}}"
+          GH_AW_ASSIGN_COPILOT: "true"
         with:
           github-token: ${{ secrets.COPILOT_CROSS_REPO_TOKEN }}
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
             const { main } = require('/opt/gh-aw/actions/safe_output_handler_manager.cjs');
+            await main();
+      - name: Assign Copilot to created issues
+        if: steps.process_safe_outputs.outputs.issues_to_assign_copilot != ''
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_ISSUES_TO_ASSIGN_COPILOT: ${{ steps.process_safe_outputs.outputs.issues_to_assign_copilot }}
+        with:
+          github-token: ${{ secrets.COPILOT_CROSS_REPO_TOKEN }}
+          script: |
+            const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('/opt/gh-aw/actions/assign_copilot_to_created_issues.cjs');
             await main();
       - name: Upload safe output items manifest
         if: always()

--- a/.github/workflows/link-checker.md
+++ b/.github/workflows/link-checker.md
@@ -39,6 +39,7 @@ safe-outputs:
   create-issue:
     max: 10
     allowed-repos: ["cncf/techdocs"]
+    assignees: [copilot]
   update-issue:
     max: 10
     target: "*"


### PR DESCRIPTION
## Changes

- **`link-checker.md`**: Added `assignees: [copilot]` to `create-issue` safe-output config — Copilot coding agent is now automatically assigned to new broken-link issues
- **`copilot-instructions.md`**: New "Broken Link Fixes" section with rules for the coding agent:
  - One PR per page (all broken links on a file grouped together)
  - Skip URLs inside backticks (code references, not navigable links)
  - Surgical diffs only — fix the URL, don't rewrite surrounding content
  - Verify replacement URLs return 200 before submitting
  - Comment on the issue instead of guessing when no valid replacement exists
  - Use `Contributes to #N` (not `Fixes`) since a single-page PR won't resolve the whole issue
- **`link-checker.lock.yml`**: Recompiled from updated frontmatter