### PR TITLE
fix: skip files with existing PRs and label fixer PRs

### DIFF
--- a/.github/workflows/link-fixer.lock.yml
+++ b/.github/workflows/link-fixer.lock.yml
@@ -25,7 +25,7 @@
 # broken-link section issue is created or updated. Reads the issue,
 # fixes the links in each page, and creates one draft PR per page.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"e262ded2cfc6150f2d0eb0afcbfb79fccfb17ff88d143c7cc57a103f49e3b015","compiler_version":"v0.57.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"2a951730dee9eb7cdaa39119ace465535be99981c67b346c2d87303e492efb0a","compiler_version":"v0.57.2","strict":true}
 
 name: "Link Fixer"
 "on":
@@ -384,7 +384,7 @@ jobs:
               "name": "add_comment"
             },
             {
-              "description": "Create a new GitHub pull request to propose code changes. Use this after making file edits to submit them for review and merging. The PR will be created from the current branch with your committed changes. For code review comments on an existing PR, use create_pull_request_review_comment instead. CONSTRAINTS: Maximum 10 pull request(s) can be created. PRs will be created as drafts.",
+              "description": "Create a new GitHub pull request to propose code changes. Use this after making file edits to submit them for review and merging. The PR will be created from the current branch with your committed changes. For code review comments on an existing PR, use create_pull_request_review_comment instead. CONSTRAINTS: Maximum 10 pull request(s) can be created. Labels [\"fixed-link\"] will be automatically added. PRs will be created as drafts.",
               "inputSchema": {
                 "additionalProperties": false,
                 "properties": {
@@ -1272,7 +1272,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.cncf.io,*.githubusercontent.com,*.kubernetes.io,*.linuxfoundation.org,*.openssf.org,*.owasp.org,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,bestpractices.coreinfrastructure.org,clomonitor.io,clotributor.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,csrc.nist.gov,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,kubernetes.io,lfs.github.com,nvlpubs.nist.gov,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,openssf.org,owasp.org,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,securityscorecards.dev,telemetry.enterprise.githubcopilot.com,todogroup.org,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"create_pull_request\":{\"allowed_files\":[\"docs/**\",\"blog/**\",\"README.md\"],\"draft\":true,\"max\":10,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"AGENTS.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\"]},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"create_pull_request\":{\"allowed_files\":[\"docs/**\",\"blog/**\",\"README.md\"],\"draft\":true,\"labels\":[\"fixed-link\"],\"max\":10,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"AGENTS.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\"]},\"missing_data\":{},\"missing_tool\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/link-fixer.md
+++ b/.github/workflows/link-fixer.md
@@ -39,6 +39,7 @@ safe-outputs:
   create-pull-request:
     max: 10
     draft: true
+    labels: [fixed-link]
     allowed-files:
       - "docs/**"
       - "blog/**"
@@ -99,7 +100,19 @@ Do NOT fix files matching these patterns:
 
 Note excluded files for the summary comment but take no action on them.
 
-#### Step 3: Fix Each Page
+#### Step 3: Skip Files With Existing PRs
+
+For each remaining file path, search for an existing open pull request in this repository with a title matching:
+
+```
+fix: correct broken links in <filename>
+```
+
+Use the GitHub MCP `list_pull_requests` tool with state `open` to search. Match by checking if any open PR title contains `correct broken links in <filename>` (where `<filename>` is the basename of the file, e.g., `marketing.md`).
+
+If an open PR already exists for that file, skip it — do not create a duplicate. Note it in the summary comment as "skipped (existing PR)".
+
+#### Step 4: Fix Each Page
 
 For each remaining file, process it **one at a time**. For each file:
 
@@ -129,7 +142,7 @@ For each remaining file, process it **one at a time**. For each file:
      ```
 5. **Reset your working tree** before moving to the next file — each PR must be independent
 
-#### Step 4: Comment on Parent Issue
+#### Step 5: Comment on Parent Issue
 
 After processing all files, add a comment to the triggering issue:
 
@@ -145,6 +158,9 @@ After processing all files, add a comment to the triggering issue:
 
 **Skipped (excluded paths):**
 - `<file-path>` — synced from cncf/techdocs
+
+**Skipped (existing PRs):**
+- #<pr-number> — `<file-path>`
 ```
 
 ### Rules


### PR DESCRIPTION
## Changes

- **New Step 3: Skip files with existing PRs** — before fixing a file, the fixer checks for open PRs with `correct broken links in <filename>` in the title. If one exists, it skips the file and reports it in the summary comment. Prevents duplicate PRs on re-runs.
- **`fixed-link` label** added to all PRs created by the fixer workflow (label already created in the repo).
- Steps renumbered: Fix → Step 4, Comment → Step 5.

Follows up on #249.