### PR TITLE
fix: skip deploy previews for link fixer PRs

### DIFF
--- a/.github/workflows/link-fixer.md
+++ b/.github/workflows/link-fixer.md
@@ -140,6 +140,8 @@ For each remaining file, process it **one at a time**. For each file:
      | old-url-2 | — | ⚠️ Could not resolve |
 
      Contributes to #<triggering-issue-number>
+
+     > **Note:** No deploy preview is generated for link-only fixes. URLs have been verified directly.
      ```
 5. **Reset your working tree** before moving to the next file — each PR must be independent
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
 publish = "build"
 command = "npm run build:preview"
+ignore = "echo $BRANCH | grep -qE '^fix/broken-links-' && exit 0 || exit 1"
 
 [context.production]
 command = "npm run build:production"


### PR DESCRIPTION
## Changes

- **`netlify.toml`**: Added `ignore` command that skips deploy previews for branches matching `fix/broken-links-*`. Production builds on `main` are unaffected. This removes the Netlify status check entirely for fixer PRs, so they won't be blocked waiting for a deploy preview on link-only markdown changes.
- **`link-fixer.md`**: PR body template now includes a note explaining why there's no deploy preview.

## Why

The fixer creates 10+ single-file PRs per run. Each one triggers a Netlify deploy preview that takes a few minutes, and they must be merged sequentially (each merge updates main, making the next PR behind). Skipping the preview eliminates the bottleneck.