### PR TITLE
fix: use [skip netlify] in PR titles instead of ignore command

### DIFF
--- a/.github/workflows/link-fixer.md
+++ b/.github/workflows/link-fixer.md
@@ -106,7 +106,7 @@ Note excluded files for the summary comment but take no action on them.
 For each remaining file path, search for an existing open pull request in this repository with a title matching:
 
 ```
-fix: correct broken links in <filename>
+fix: correct broken links in <filename> [skip netlify]
 ```
 
 Use the GitHub MCP `list_pull_requests` tool with state `open` to search. Match by checking if any open PR title contains `correct broken links in <filename>` (where `<filename>` is the basename of the file, e.g., `marketing.md`).
@@ -128,7 +128,7 @@ For each remaining file, process it **one at a time**. For each file:
    c. If you cannot find a valid replacement, **do not guess** — skip that link and note it in the summary
 3. **Edit the file** with only the corrected URLs — do not change any surrounding content, formatting, or structure
 4. **Create a pull request** with:
-   - **Title:** `fix: correct broken links in <filename>`
+   - **Title:** `fix: correct broken links in <filename> [skip netlify]`
    - **Branch name:** `fix/broken-links-<filename-without-extension>`
    - **Body:**
      ```

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,6 @@
 [build]
 publish = "build"
 command = "npm run build:preview"
-ignore = "echo $BRANCH | grep -qE '^fix/broken-links-' && exit 0 || exit 1"
 
 [context.production]
 command = "npm run build:production"


### PR DESCRIPTION
## Summary

Replaces the non-functional `ignore` command in `netlify.toml` with Netlify's native `[skip netlify]` PR title tag.

## Changes

- **`netlify.toml`**: Removed `ignore` command — it only applies to branch deploys, not deploy previews
- **`link-fixer.md`**: Added `[skip netlify]` to the PR title template so future fixer PRs skip deploy previews entirely

## Context

PR #280 added an `ignore` command to `netlify.toml` to skip deploy previews for `fix/broken-links-*` branches. Testing showed this doesn't work for deploy previews — Netlify's `ignore` only applies to branch deploys.

Per [Netlify docs](https://docs.netlify.com/site-deploys/manage-deploys/#skip-builds), adding `[skip netlify]` to the PR title is the supported way to skip deploy previews.

> **Note:** Existing fixer PRs can be updated by appending `[skip netlify]` to their titles.