### PR TITLE
fix: create fixer PRs as ready for review instead of draft

### DIFF
--- a/.github/workflows/link-fixer.lock.yml
+++ b/.github/workflows/link-fixer.lock.yml
@@ -23,9 +23,9 @@
 #
 # Fixes broken links detected by the link checker. Triggered when a
 # broken-link section issue is created or updated. Reads the issue,
-# fixes the links in each page, and creates one draft PR per page.
+# fixes the links in each page, and creates one PR per page.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"e162847a8868761297ea75b8b5e9b961bf64be6f6634a7af51b7f55816b03f64","compiler_version":"v0.57.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"577ea93799dc1917732e274277581c960e27b096f0cf07cfdf5cd0d7f7a7729d","compiler_version":"v0.57.2","strict":true}
 
 name: "Link Fixer"
 "on":
@@ -342,7 +342,7 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"add_comment":{"max":1},"create_pull_request":{"draft":true,"max":10},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
+          {"add_comment":{"max":1},"create_pull_request":{"max":10},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
@@ -384,7 +384,7 @@ jobs:
               "name": "add_comment"
             },
             {
-              "description": "Create a new GitHub pull request to propose code changes. Use this after making file edits to submit them for review and merging. The PR will be created from the current branch with your committed changes. For code review comments on an existing PR, use create_pull_request_review_comment instead. CONSTRAINTS: Maximum 10 pull request(s) can be created. Labels [\"fixed-link\"] will be automatically added. PRs will be created as drafts.",
+              "description": "Create a new GitHub pull request to propose code changes. Use this after making file edits to submit them for review and merging. The PR will be created from the current branch with your committed changes. For code review comments on an existing PR, use create_pull_request_review_comment instead. CONSTRAINTS: Maximum 10 pull request(s) can be created. Labels [\"fixed-link\"] will be automatically added.",
               "inputSchema": {
                 "additionalProperties": false,
                 "properties": {
@@ -959,7 +959,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           WORKFLOW_NAME: "Link Fixer"
-          WORKFLOW_DESCRIPTION: "Fixes broken links detected by the link checker. Triggered when a\nbroken-link section issue is created or updated. Reads the issue,\nfixes the links in each page, and creates one draft PR per page."
+          WORKFLOW_DESCRIPTION: "Fixes broken links detected by the link checker. Triggered when a\nbroken-link section issue is created or updated. Reads the issue,\nfixes the links in each page, and creates one PR per page."
           HAS_PATCH: ${{ steps.collect_output.outputs.has_patch }}
         with:
           script: |
@@ -1272,7 +1272,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.cncf.io,*.githubusercontent.com,*.kubernetes.io,*.linuxfoundation.org,*.openssf.org,*.owasp.org,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,bestpractices.coreinfrastructure.org,clomonitor.io,clotributor.dev,cncf.io,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,csrc.nist.gov,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,kubernetes.io,lfs.github.com,nvlpubs.nist.gov,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,openssf.org,owasp.org,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,securityscorecards.dev,telemetry.enterprise.githubcopilot.com,todogroup.org,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"create_pull_request\":{\"allowed_files\":[\"docs/**\",\"blog/**\",\"README.md\"],\"draft\":true,\"labels\":[\"fixed-link\"],\"max\":10,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"AGENTS.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\"]},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"create_pull_request\":{\"allowed_files\":[\"docs/**\",\"blog/**\",\"README.md\"],\"draft\":false,\"labels\":[\"fixed-link\"],\"max\":10,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"AGENTS.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\"]},\"missing_data\":{},\"missing_tool\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/link-fixer.md
+++ b/.github/workflows/link-fixer.md
@@ -2,7 +2,7 @@
 description: |
   Fixes broken links detected by the link checker. Triggered when a
   broken-link section issue is created or updated. Reads the issue,
-  fixes the links in each page, and creates one draft PR per page.
+  fixes the links in each page, and creates one PR per page.
 
 on:
   issues:
@@ -39,7 +39,7 @@ network:
 safe-outputs:
   create-pull-request:
     max: 10
-    draft: true
+    draft: false
     labels: [fixed-link]
     allowed-files:
       - "docs/**"
@@ -64,7 +64,7 @@ Your name is ${{ github.workflow }}. You are a **Broken Link Fixer** for the rep
 
 ### Mission
 
-When the link checker creates or updates a broken-link section issue, fix the broken links and create one draft PR per page. Each PR should contain only the corrected URLs for a single file — nothing else.
+When the link checker creates or updates a broken-link section issue, fix the broken links and create one PR per page. Each PR should contain only the corrected URLs for a single file — nothing else.
 
 ### Prerequisites
 


### PR DESCRIPTION
## Summary

Changes fixer PRs from draft to ready-for-review on creation.

## Rationale

Draft PRs require someone to manually mark them ready before they can be merged. Since the fixer already verifies all replacement URLs with `curl` before creating the PR, the draft step adds friction without adding safety. Removing it streamlines the approve-and-merge workflow.

## Changes

- `link-fixer.md`: Set `draft: false` in frontmatter, updated prompt references
- `link-fixer.lock.yml`: Recompiled