### PR TITLE
fix: add rule to prevent closing keywords in fixer PRs

### DIFF
--- a/.github/workflows/link-fixer.md
+++ b/.github/workflows/link-fixer.md
@@ -173,3 +173,4 @@ After processing all files, add a comment to the triggering issue:
 5. **Verify every replacement.** Every new URL must return a 200 status before you include it in a PR.
 6. **Do not guess.** If you cannot find a valid replacement, skip the link and report it in the summary comment.
 7. **Each PR must be independent.** Reset your working tree between files so PRs do not contain changes from other files.
+8. **Never use closing keywords.** Do not use `Fixes`, `Closes`, or `Resolves` in PR bodies — each PR fixes only one file, not the entire issue. Use only `Contributes to #<number>`.


### PR DESCRIPTION
## Summary

Adds rule 8 to the link fixer prompt: never use `Fixes`, `Closes`, or `Resolves` in PR bodies.

## Problem

The fixer agent was adding `- Fixes #NNN` to PR bodies alongside the correct `Contributes to #NNN`. Since each PR only fixes one file out of potentially dozens of broken links in an issue, merging any single PR would auto-close the entire parent issue.

## Fix

- Added explicit rule: use only `Contributes to` — never closing keywords
- Cleaned up all 15 existing fixer PR bodies to remove the `- Fixes` lines