### PR TITLE
Replace Bevy with Open Community Groups for meetings

### DIFF
--- a/docs/projects/best-practices/community/vendor-neutrality.md
+++ b/docs/projects/best-practices/community/vendor-neutrality.md
@@ -40,7 +40,7 @@ Many adopters may be interested in commercial support for CNCF projects, but may
 
 Wherever possible, community meetings, events, resources, and infrastructure should be hosted on resources belonging to the CNCF, or on other neutral, 3rd-party resources (like GitHub).  Good resources to use include:
 
-* CNCF Zoom or Bevy for meetings
+* CNCF Zoom or Open Community Groups for meetings
 * GitHub or Netlify static site hosting for website and docs
 * CNCF cloud credits for testing
 * CNCF-shared YouTube account for videos


### PR DESCRIPTION
Updated the hosting resources section to include Open Community Groups as an option for meetings.

<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://github.com/cncf/contribute-site/blob/main/CONTRIBUTING.md) page.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---
