### PR TITLE
Correct platform reference for TCG roles documentation

### DIFF
--- a/docs/community/governance/tech-group-governance.md
+++ b/docs/community/governance/tech-group-governance.md
@@ -668,8 +668,8 @@ meetings, promoting the group, and coordinating the creation of initiatives.
 #### Other Roles
 
 TCG's MAY have other roles, but they are REQUIRED to be documented in an
-easily discovered area, such as the groups's page on Bevy; the platform used
-by Community Groups.
+easily discovered area, such as the groups's page on Open Community Grouos; the platform used
+by Cloud Native Community Groups (CNCGs).
 
 - MUST be documented with a description, scope, and responsibilities.
 - MUST adhere to the [Technical Leadership Principles].


### PR DESCRIPTION
Updated the documentation to reflect the correct platform for TCG roles.

<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://github.com/cncf/contribute-site/blob/main/CONTRIBUTING.md) page.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---
