### PR TITLE
Add PDF publication date to IAM WP

### DIFF
--- a/docs/community/tags/security-and-compliance/publications/iam-whitepaper/index.md
+++ b/docs/community/tags/security-and-compliance/publications/iam-whitepaper/index.md
@@ -8,9 +8,7 @@ sidebar_position: 1
 <!-- cspell:disable -->
 **Version**: 1.1 **Created**: 22 Mar 2026 **Status**: WIP | In Review | **Approved**
 
-**Last Reviewed**: 24 Apr 2026 **PDF Published**: TBD **Release Version**: 1.1
-
-**Final PDF Approvers** TBD
+**Last Reviewed**: 24 Apr 2026 **PDF Published**: 04 Jun 2026 **Release Version**: 1.1
 
 **Version 1 (Apr 2026)**
 


### PR DESCRIPTION
The PDF version of the IAM white paper has been published, so I have added the release date of the PDF version.
https://www.cncf.io/blog/2026/06/04/identity-and-access-management-whitepaper/