### PR TITLE
Move awards

### DIFF
--- a/docs/community/awards.md
+++ b/docs/community/awards.md
@@ -8,16 +8,22 @@ CNCF Community Awards will reward the community members, developers and advocate
 
 We traditionally have the following awards, rewarded at different times of each calendar year:
 
+- **Top Ambassador**: A champion for the cloud native space, this individual helps spread awareness of the CNCF and its projects. The CNCF Ambassador leverages multiple platforms, both online as well as speaking engagements, driving interest and excitement around the ecosystem.
 - **Top Committer**: This award recognizes excellence in technical contributions to CNCF and its hosted projects. The CNCF Top Committer has made key commits to projects and, more importantly, contributes in a way that benefits the project as a whole.
 - **Top End User**: The special award for the [CNCF End User Community](https://www.cncf.io/enduser/) representatives in recognition of major contributions to the cloud native ecosystem. All end users can be nominated, but end user members can not win two consecutive years in a row.
-- **Lorem Ipsum (prev. Top Documentarian)** (since 2021): This award recognizes excellence in documentation contributions to CNCF and its projects. Excellent technical documentation is one of the best ways projects can lower the barrier to contribution.
+- **Lorem Ipsum** (Previously Top Documentarian, since 2021): This award recognizes excellence in documentation contributions to CNCF and its projects. Excellent technical documentation is one of the best ways projects can lower the barrier to contribution.
 - **Chop Wood Carry Water Award**: This award is given to community members helping behind the scenes, dedicating countless hours to open source projects, hosting and building community meetups, and often completing thankless tasks for the benefit of the community.
 - **The TAGGIE**: This award is presented to the person who has done the most to advance CNCF’s [Technical Advisory Groups](https://github.com/cncf/toc/tree/main/tags) (TAGs). TAGs scale contributions by the CNCF technical and user community, while retaining integrity and increasing quality in support of CNCF’s mission of making cloud native ubiquitous.
+- **Small but Mighty**: This award recognizes the company or organization in the community with the largest impact. CNCF is made up of hundreds of thousands of individuals and organizations, each providing valuable contributions, but this award is presented to an organization punching above its weight.
 
 ## Table of contents
 
 - CNCF Community Awards
 - [Awarded](#awarded)
+  - [2026](#2026)
+    - [Top End User](#2026-top-end-user)
+    - [Outstanding Mentor](#2026-outstanding-mentor)
+    - [The TAGGIE](#2026-the-taggie)
   - [2025](#2025)
     - [Top End Users](#2025-top-end-users)
     - [Lifetime Achievement](#2025-lifetime-achievement)
@@ -76,6 +82,24 @@ We traditionally have the following awards, rewarded at different times of each 
     - [Top Committer](#2016-top-committer)
 
 ## Awarded
+
+### 2026
+
+#### 2026 Top End User
+
+- [SNCF](https://www.sncf-voyageurs.com/en/)
+
+#### 2026 Outstanding Mentor
+
+- [Hung-Ying Tai (hydai)](https://www.linkedin.com/in/hydai/)
+
+#### 2026 The TAGGIE
+
+- [Brandt Keller](https://www.cncf.io/people/ambassadors/?p=brandt-keller)
+- [Carol Valencia](https://www.linkedin.com/in/dylandanielpage/)
+- [Dylan Page](https://www.linkedin.com/in/dylandanielpage/)
+- [Josh Gavant](https://www.cncf.io/people/ambassadors/?p=josh-gavant)
+- [Yoshiyuki Tabata](https://www.cncf.io/people/ambassadors/?p=yoshiyuki-tabata)
 
 ### 2025
 


### PR DESCRIPTION
This pulls all the latest updates from the github.com/cncf/awards repo over here. That repo can now be archived.