### PR TITLE
docs: clarify link-fixer should not change link extension style

### DIFF
--- a/.github/workflows/link-fixer.md
+++ b/.github/workflows/link-fixer.md
@@ -174,3 +174,4 @@ After processing all files, add a comment to the triggering issue:
 6. **Do not guess.** If you cannot find a valid replacement, skip the link and report it in the summary comment.
 7. **Each PR must be independent.** Reset your working tree between files so PRs do not contain changes from other files.
 8. **Never use closing keywords.** Do not use `Fixes`, `Closes`, or `Resolves` in PR bodies — each PR fixes only one file, not the entire issue. Use only `Contributes to #<number>`.
+9. **Preserve the link's extension style.** When fixing a broken link, only correct what's actually wrong (the path, typo, or domain). Do not add a `.md` extension to a link that didn't originally have one, and do not strip a `.md` extension that was already present. Changing the style is an unrelated edit and violates Rule 4.


### PR DESCRIPTION
## What
Adds a rule to the link-fixer workflow instructing it to preserve a link's
existing extension style (`.md` or no extension) when fixing broken links —
it should only correct what's actually wrong (path, typo, domain), not
change the link style itself.

## Why
This closes #302. The original concern was that the live site strips `.md`
from links, so the bot shouldn't add it. That assumption was actually
disproven in the #266 discussion — Docusaurus resolves both `.md` and
extension-less links fine, and `.md` links are already used throughout the
docs (e.g. `docs/community/tags/index.md`). So the real gap wasn't "always
strip .md" — it was that the workflow had no explicit rule stopping it from
changing a link's style at all, which is an unrelated edit under Rule 4.
This adds that guardrail.

Contributes to #302
