### PR TITLE
Fix: navbar overlap at 1000-1200px widths

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -113,3 +113,39 @@
     scroll-margin-top: 5rem;
 }
 
+/**
+ * Fix for issue #202: top nav items overlap the logo/title at
+ * intermediate widths (roughly 1000px-1200px). Docusaurus only
+ * switches to the mobile hamburger menu at 996px and below, so
+ * above that every navbar item renders in a single row. With 8
+ * items (4 left + 4 right, including the logo/title) there isn't
+ * enough horizontal space in that range, causing overlap.
+ *
+ * This tightens spacing and font-size only in that intermediate
+ * range so all items fit on one line without wrapping or
+ * overlapping, while leaving the normal desktop (>1200px) and
+ * mobile (<=996px) layouts untouched.
+ */
+@media (min-width: 997px) and (max-width: 1200px) {
+  .navbar__items {
+    gap: 0.25rem;
+  }
+
+  .navbar__item {
+    padding: 0 0.35rem;
+  }
+
+  .navbar__link {
+    font-size: 0.85rem;
+    padding: var(--ifm-navbar-item-padding-vertical) 0.4rem;
+    white-space: nowrap;
+  }
+
+  .navbar__title {
+    font-size: 0.9rem;
+  }
+
+  .navbar__logo {
+    height: 2rem;
+  }
+}


### PR DESCRIPTION
Fixes #202

## Problem
The top navbar (logo + 8 nav items) overlaps at intermediate viewport
widths, roughly between 1000px and 1200px. Docusaurus only switches
to the mobile hamburger menu at 996px and below, so above that all
navbar items render in a single row — with 8 items plus the logo,
there isn't enough horizontal space in that range, causing overlap.

## Fix
Added a scoped media query in `src/css/custom.css` targeting
`997px–1200px` only. It tightens spacing, link padding, font-size,
and logo height just enough for all items to fit on one line without
wrapping or overlapping. The normal desktop layout (>1200px) and the
mobile hamburger layout (<=996px) are untouched.

## Testing
- Ran `npm start` locally and resized the browser through 997px,
  1050px, 1100px, 1200px, and 1201px+ to confirm no overlap and no
  regression at other widths.
- Verified in both light and dark mode.

