### PR TITLE
docs(projects): add Contacting the TOC guidance page

### DIFF
--- a/docs/community/toc/index.md
+++ b/docs/community/toc/index.md
@@ -76,6 +76,8 @@ All meetings can be joined directly from the calendar. Meetings are open to the 
 
 ## Communication Channels
 
+Projects looking for the right way to reach the TOC or raise an issue can start with [Contacting the TOC](/projects/contact-the-toc/).
+
 ### Mailing Lists
 
 **Public Mailing List**: For general TOC discussions and announcements

--- a/docs/projects/contact-the-toc.md
+++ b/docs/projects/contact-the-toc.md
@@ -1,0 +1,71 @@
+---
+title: Contacting the TOC
+description: How CNCF projects can reach the Technical Oversight Committee, raise issues, and find guidance
+sidebar_position: 11
+tags:
+  - toc
+  - projects
+  - governance
+---
+
+# Contacting the TOC
+
+This page helps CNCF projects and maintainers find the right way to reach the Technical Oversight Committee (TOC), raise an issue, or locate the guidance you need. Pick the channel that matches your situation below.
+
+## Quick reference
+
+| If you need to... | Use |
+|-------------------|-----|
+| Ask a general question | [`#toc` on CNCF Slack](https://cloud-native.slack.com/archives/C0MP69YF4), the [public mailing list](https://lists.cncf.io/g/cncf-toc), or email [info@cncf.io](mailto:info@cncf.io) |
+| Apply to move levels or ask about an application | Open an [issue in the TOC repository](https://github.com/cncf/toc/issues) and see [Project Lifecycle and Process](/projects/lifecycle/) |
+| Report a governance concern (public) | File a [Governance issue in the TOC repository](https://github.com/cncf/toc/issues) |
+| Report a governance concern anonymously or confidentially | Email the [private mailing list](mailto:cncf-private-toc@lists.cncf.io) |
+| Raise a sensitive or leadership issue | Email the [private mailing list](mailto:cncf-private-toc@lists.cncf.io) |
+| Give feedback or observe the TOC's work | Attend a [TOC meeting](/community/toc/#meeting-information) or comment on [GitHub issues](https://github.com/cncf/toc/issues) |
+
+## General questions
+
+For everyday questions about the TOC, the project lifecycle, or where to find something:
+
+- **Slack:** join the [CNCF Slack](https://slack.cncf.io/) and post in [`#toc`](https://cloud-native.slack.com/archives/C0MP69YF4).
+- **Public mailing list:** [cncf-toc@lists.cncf.io](https://lists.cncf.io/mailman/listinfo/cncf-toc) ([browse the archive](https://lists.cncf.io/g/cncf-toc)).
+- **CNCF staff:** email [info@cncf.io](mailto:info@cncf.io) if you are unsure who to ask.
+
+## Project applications and moving levels
+
+If your project is applying to join the CNCF or move from one maturity level to the next, start with the process documentation and then open an issue so the TOC can track and assign your application:
+
+- [Project Lifecycle and Process](/projects/lifecycle/)
+- [How Projects Move Levels](/projects/moving-levels/)
+- [How to Submit a Project](/projects/submit-project/)
+- Open an [issue in the TOC repository](https://github.com/cncf/toc/issues) to begin
+
+The TOC's [Due Diligence Guide](/community/toc/operations/dd-toc-guide/) explains how the committee evaluates projects, so you can see what to expect during a review.
+
+## Governance concerns
+
+Governance issues, including behavioral concerns involving project leaders, are handled through the TOC's [governance remediation process](https://github.com/cncf/toc/blob/main/operations/governance-remediation-process.md). There are three ways to report, depending on the sensitivity involved:
+
+- **Public reports:** in most cases, file a Governance-type [issue in the TOC repository](https://github.com/cncf/toc/issues). If a concern is first raised in another venue, a tracking issue should still be created in the TOC repo for assignment.
+- **Anonymous reports:** if you would prefer your name not be known, email [cncf-private-toc@lists.cncf.io](mailto:cncf-private-toc@lists.cncf.io). The TOC will create a tracking issue, and your identity will be known only to the TOC team.
+- **Confidential reports:** if there are risks around the details being public, email [cncf-private-toc@lists.cncf.io](mailto:cncf-private-toc@lists.cncf.io). The TOC and the assessment team will track the request through privately shared documents.
+
+Leadership and behavioral concerns can be raised as violations of the [Technical Leadership Principles](https://github.com/cncf/toc/blob/main/PRINCIPLES.md#technical-leadership-principles).
+
+## Sensitive issues
+
+When public discussion is not appropriate, reach the TOC privately through the [private mailing list](mailto:cncf-private-toc@lists.cncf.io). Use this for matters that need confidentiality rather than for general questions.
+
+## Meetings and feedback
+
+TOC meetings are open to the public and are a good way to observe the committee's work or share your perspective. See [Meeting Information](/community/toc/#meeting-information) for the schedule, calendar, agendas, and recordings. You can also share feedback by commenting on [GitHub issues](https://github.com/cncf/toc/issues) or posting to the [mailing list](https://lists.cncf.io/g/cncf-toc).
+
+## Where to find guidance
+
+- [Technical Oversight Committee (TOC)](/community/toc/) - overview, members, communication channels, and structure
+- [TOC Operations](/community/toc/operations/) - the committee's documented processes
+- [Due Diligence Guide](/community/toc/operations/dd-toc-guide/) - how projects are evaluated when moving levels
+- [Project Health Review](/community/toc/operations/project-health-review/) - how the TOC assesses ongoing project health
+- [Project Lifecycle and Process](/projects/lifecycle/) - stages, criteria, and how to move levels
+- [Project Best Practices](/projects/best-practices/) - governance, security, community, and accessibility guidance
+- [CNCF Principles](https://github.com/cncf/toc/blob/main/PRINCIPLES.md) - the technical and leadership principles projects are expected to uphold


### PR DESCRIPTION
## What

Adds a project-facing **Contacting the TOC** page at `/projects/contact-the-toc/` that consolidates, in one place, how CNCF projects and maintainers can reach the Technical Oversight Committee and find guidance.

## Why

Contact guidance is currently spread across several documents (README for mailing lists and Slack, the governance remediation process for reporting paths, the FAQ for general questions). There is no single entry point for a project that just needs to know *where to go*. This page gives maintainers one discoverable starting point.

## Contents

- **Quick reference table** mapping a need to the right channel
- **General questions** - `#toc` Slack, public mailing list, info@cncf.io
- **Applications and moving levels** - TOC issues plus links to lifecycle, moving levels, submit a project, and the Due Diligence guide
- **Governance concerns** - the public, anonymous, and confidential reporting paths from the governance remediation process, plus the Technical Leadership Principles
- **Sensitive issues** - the private mailing list
- **Meetings and feedback**
- **Where to find guidance** - a link hub to the TOC overview, operations, DD guide, project health review, lifecycle, best practices, and Principles

Also adds a one-line pointer from the TOC index Communication Channels section to the new page for discoverability.

All external links and addresses are sourced from the cncf/toc repository (README, governance-remediation-process, PRINCIPLES, FAQ). The page auto-appears in the Projects sidebar via DocCardList.

🤖 Generated with [Claude Code](https://claude.com/claude-code)